### PR TITLE
Append features once, then reselect for data bind

### DIFF
--- a/src/features/arc-series.js
+++ b/src/features/arc-series.js
@@ -67,12 +67,12 @@
           .outerRadius(r - aw);
 
         var group = d4.appendOnce(selection, 'g.' + name);
-        var arcGroups = group.selectAll('g')
+        var arcGroups = group.selectAll('g.' + name + '-group')
           .data(data);
 
-        arcGroups.enter()
-          .append('g')
-          .attr('class', name)
+        arcGroups.enter().append('g');
+
+        arcGroups.attr('class', name + '-group')
           .attr('transform', 'translate(' + x + ',' + y + ')');
 
         var arcs = arcGroups.selectAll('path')
@@ -80,15 +80,14 @@
             return d.values;
           }, d4.functor(scope.accessors.key).bind(this));
 
+        arcs.enter().append('path');
         // update
         arcs.transition()
           .duration(d4.functor(scope.accessors.duration).bind(this)())
           .attrTween('d', arcTween);
 
         // create new elements as needed
-        arcs.enter()
-          .append('path')
-          .attr('class', d4.functor(scope.accessors.classes).bind(this))
+        arcs.attr('class', d4.functor(scope.accessors.classes).bind(this))
           .attr('data-key', d4.functor(scope.accessors.key).bind(this))
           .attr('d', arc)
           .each(function(d) {

--- a/src/features/arc-series.js
+++ b/src/features/arc-series.js
@@ -66,13 +66,16 @@
           .innerRadius(r)
           .outerRadius(r - aw);
 
-        var group = selection.selectAll('g.' + name).data(data);
-        group.enter()
+        var group = selection.selectAll('g.' + name);
+        var arcGroups = group.selectAll('g')
+          .data(data);
+
+        arcGroups.enter()
           .append('g')
           .attr('class', name)
           .attr('transform', 'translate(' + x + ',' + y + ')');
 
-        var arcs = group.selectAll('path')
+        var arcs = arcGroups.selectAll('path')
           .data(function(d) {
             return d.values;
           }, d4.functor(scope.accessors.key).bind(this));
@@ -94,7 +97,7 @@
 
         //remove old elements as needed
         arcs.exit().remove();
-        group.exit().remove();
+        arcGroups.exit().remove();
         return arc;
       }
     };

--- a/src/features/arc-series.js
+++ b/src/features/arc-series.js
@@ -66,7 +66,7 @@
           .innerRadius(r)
           .outerRadius(r - aw);
 
-        var group = selection.selectAll('g.' + name);
+        var group = d4.appendOnce(selection, 'g.' + name);
         var arcGroups = group.selectAll('g')
           .data(data);
 

--- a/src/features/column-labels.js
+++ b/src/features/column-labels.js
@@ -43,12 +43,12 @@
         }
       },
       render: function(scope, data, selection) {
-        selection.append('g').attr('class', name);
-        var label = this.container.select('.' + name).selectAll('.' + name)
+        var group = d4.appendOnce(selection, 'g.' + name);
+        var label = group.selectAll('text')
           .data(data, d4.functor(scope.accessors.key).bind(this));
         label.enter().append('text');
         label.exit().remove();
-        label.attr('class', 'column-label')
+        label.attr('class', 'column-label ' + name)
           .text(d4.functor(scope.accessors.text).bind(this))
           .attr('text-anchor', anchorText.bind(this))
           .attr('x', d4.functor(scope.accessors.x).bind(this))

--- a/src/features/grid.js
+++ b/src/features/grid.js
@@ -34,28 +34,31 @@
         var formattedXAxis = d4.functor(scope.accessors.formatXAxis).bind(this)(xAxis);
         var formattedYAxis = d4.functor(scope.accessors.formatYAxis).bind(this)(yAxis);
 
-        selection.append('g').attr('class', 'grid border ' + name)
+        var grid = d4.appendOnce(selection, 'g.grid.border.' + name);
+        var gridBg = d4.appendOnce(grid, 'rect');
+        var gridX = d4.appendOnce(grid, 'g.x.grid.' + name);
+        var gridY = d4.appendOnce(grid, 'g.y.grid.' + name);
+
+        gridBg
           .attr('transform', 'translate(0,0)')
-          .append('rect')
           .attr('x', 0)
           .attr('y', 0)
           .attr('width', this.width)
           .attr('height', this.height);
 
-        selection.append('g')
-          .attr('class', 'x grid ' + name)
+        gridX
           .attr('transform', 'translate(0,' + this.height + ')')
           .call(formattedXAxis
             .tickSize(-this.height, 0, 0)
             .tickFormat(''));
 
-        selection.append('g')
-          .attr('class', 'y grid ' + name)
+        gridY
           .attr('transform', 'translate(0,0)')
           .call(formattedYAxis
             .tickSize(-this.width, 0, 0)
             .tickFormat(''));
-        return selection;
+
+        return grid;
       }
     };
   });

--- a/src/features/grouped-column-series.js
+++ b/src/features/grouped-column-series.js
@@ -85,20 +85,28 @@
         }
       },
       render: function(scope, data, selection) {
-        selection.append('g').attr('class', name);
-        var group = this.container.select('.' + name).selectAll('g')
+        if (data.length > 0) {
+          this.groupsOf = this.groupsOf || data[0].values.length;
+        }
+
+        var group = d4.appendOnce(selection, 'g.' + name);
+
+        var columnGroups = group.selectAll('g')
           .data(data, d4.functor(scope.accessors.key).bind(this));
-        group.enter().append('g');
-        group.exit().remove();
-        group.attr('class', function(d, i) {
+
+        columnGroups.enter().append('g');
+        columnGroups.exit().remove();
+        columnGroups.attr('class', function(d, i) {
           return 'series' + i + ' ' + this.x.$key;
         }.bind(this));
 
-        var rect = group.selectAll('rect')
+        var rect = columnGroups.selectAll('rect')
           .data(function(d) {
             return d.values;
-          }.bind(this));
-        rect.enter().append('rect')
+          }.bind(this))
+          .enter().append('rect');
+
+        columnGroups.selectAll('rect')
           .attr('class', d4.functor(scope.accessors.classes).bind(this))
           .attr('x', d4.functor(scope.accessors.x).bind(this))
           .attr('y', d4.functor(scope.accessors.y).bind(this))

--- a/src/features/grouped-column-series.js
+++ b/src/features/grouped-column-series.js
@@ -95,7 +95,6 @@
           .data(data, d4.functor(scope.accessors.key).bind(this));
 
         columnGroups.enter().append('g');
-        columnGroups.exit().remove();
         columnGroups.attr('class', function(d, i) {
           return 'series' + i + ' ' + this.x.$key;
         }.bind(this));
@@ -103,10 +102,11 @@
         var rect = columnGroups.selectAll('rect')
           .data(function(d) {
             return d.values;
-          }.bind(this))
-          .enter().append('rect');
+          }.bind(this));
 
-        columnGroups.selectAll('rect')
+        rect.enter().append('rect');
+
+        rect
           .attr('class', d4.functor(scope.accessors.classes).bind(this))
           .attr('x', d4.functor(scope.accessors.x).bind(this))
           .attr('y', d4.functor(scope.accessors.y).bind(this))
@@ -114,6 +114,10 @@
           .attr('rx', d4.functor(scope.accessors.rx).bind(this))
           .attr('width', d4.functor(scope.accessors.width).bind(this))
           .attr('height', d4.functor(scope.accessors.height).bind(this));
+
+        rect.exit().remove();
+        columnGroups.exit().remove();
+
         return rect;
       }
     };

--- a/src/features/line-series-labels.js
+++ b/src/features/line-series-labels.js
@@ -141,11 +141,10 @@
       },
 
       render: function(scope, data, selection) {
-        selection.append('g').attr('class', name);
-        var label = this.container.select('.' + name).selectAll('.' + name).data(data);
+        var group = d4.appendOnce(selection, 'g.' + name);
+        var label = group.selectAll('.seriesLabel').data(data);
         label.enter().append('text');
-        label.exit().remove();
-        label.attr('class', 'line-series-label')
+        label
           .text(d4.functor(scope.accessors.text).bind(this))
           .attr('x', d4.functor(scope.accessors.x).bind(this))
           .attr('y', d4.functor(scope.accessors.y).bind(this))
@@ -155,6 +154,7 @@
           }.bind(this));
         displayXValue.bind(this)(scope, data, selection);
 
+        label.exit().remove();
         return label;
       }
     };

--- a/src/features/line-series.js
+++ b/src/features/line-series.js
@@ -27,24 +27,27 @@
         target: line
       }],
       render: function(scope, data, selection) {
-        selection.append('g').attr('class', name);
+        var group = d4.appendOnce(selection, 'g.' + name);
         line
           .x(d4.functor(scope.accessors.x).bind(this))
           .y(d4.functor(scope.accessors.y).bind(this));
 
-        var group = selection.select('.' + name).selectAll('g')
+        var lineGroups = group.selectAll('g')
           .data(data, d4.functor(scope.accessors.key).bind(this));
-        group.exit().remove();
-        group.enter().append('g')
+
+        lineGroups.exit().remove();
+        lineGroups.enter().append('g')
           .attr('data-key', function(d) {
             return d.key;
           })
-          .attr('class', d4.functor(scope.accessors.classes).bind(this))
-          .append('path')
-          .attr('d', function(d) {
-            return line(d.values);
-          });
-        return group;
+          .attr('class', d4.functor(scope.accessors.classes).bind(this));
+
+        d4.appendOnce(lineGroups, 'path');
+
+        lineGroups.selectAll('path').attr('d', function(d) {
+          return line(d.values);
+        });
+        return lineGroups;
       }
     };
   });

--- a/src/features/line-series.js
+++ b/src/features/line-series.js
@@ -35,18 +35,23 @@
         var lineGroups = group.selectAll('g')
           .data(data, d4.functor(scope.accessors.key).bind(this));
 
-        lineGroups.exit().remove();
         lineGroups.enter().append('g')
           .attr('data-key', function(d) {
             return d.key;
           })
           .attr('class', d4.functor(scope.accessors.classes).bind(this));
 
-        d4.appendOnce(lineGroups, 'path');
+        var lines = lineGroups.selectAll('path')
+          .data(function(d) { return [d]; });
 
-        lineGroups.selectAll('path').attr('d', function(d) {
+        lines.enter().append('path');
+        lines.attr('d', function(d) {
           return line(d.values);
         });
+
+        lines.exit().remove();
+        lineGroups.exit().remove();
+
         return lineGroups;
       }
     };

--- a/src/features/reference-line.js
+++ b/src/features/reference-line.js
@@ -30,8 +30,10 @@
         }
       },
       render: function(scope, data, selection) {
-        selection.append('g').attr('class', name);
-        var referenceLine = d4.appendOnce(this.container.select('.' + name), 'line')
+        var group = d4.appendOnce(selection, 'g.' + name);
+        var referenceLine = d4.appendOnce(group, 'line');
+
+        group.select('line')
           .attr('class', d4.functor(scope.accessors.classes).bind(this))
           .attr('x1', d4.functor(scope.accessors.x1).bind(this))
           .attr('x2', d4.functor(scope.accessors.x2).bind(this))

--- a/src/features/stacked-column-connectors.js
+++ b/src/features/stacked-column-connectors.js
@@ -57,21 +57,21 @@
       },
 
       render: function(scope, data, selection) {
-        selection.append('g').attr('class', name);
-        var group = this.container.select('.' + name).selectAll('g')
-          .data(data)
-          .enter().append('g')
+        var group = d4.appendOnce(selection, 'g.' + name);
+        var connectorGroups = group.selectAll('g')
+          .data(data);
+
+        connectorGroups.enter().append('g')
           .attr('class', function(d, i) {
             return 'series' + i + ' ' + this.y.$key;
           }.bind(this));
 
-        var lines = group.selectAll('lines')
+        var lines = connectorGroups.selectAll('line')
           .data(function(d) {
             return d.values;
           }.bind(this));
 
         lines.enter().append('line');
-        lines.exit().remove();
         lines
           .attr('class', d4.functor(scope.accessors.classes).bind(this))
           .attr('stroke-dasharray', '5, 5')
@@ -101,6 +101,8 @@
           });
         }.bind(this));
 
+        connectorGroups.exit().remove();
+        lines.exit().remove();
         return lines;
       }
     };

--- a/src/features/stacked-labels.js
+++ b/src/features/stacked-labels.js
@@ -105,13 +105,17 @@
           .data(function(d) {
             return d.values;
           }.bind(this));
-        text.enter().append('text')
+
+        text.enter().append('text');
+
+        text
           .text(d4.functor(scope.accessors.text).bind(this))
           .attr('text-anchor', d4.functor(scope.accessors.textAnchor).bind(this))
           .attr('class', d4.functor(scope.accessors.classes).bind(this))
           .attr('y', d4.functor(scope.accessors.y).bind(this))
           .attr('x', d4.functor(scope.accessors.x).bind(this));
 
+        labelGroups.exit().remove();
         text.exit().remove();
 
         if (d4.functor(scope.accessors.stagger).bind(this)()) {

--- a/src/features/stacked-labels.js
+++ b/src/features/stacked-labels.js
@@ -89,16 +89,19 @@
       },
 
       render: function(scope, data, selection) {
-        selection.append('g').attr('class', name);
-        var group = this.container.select('.' + name).selectAll('g')
+        var group = d4.appendOnce(selection, 'g.' + name);
+
+        var labelGroups = group.selectAll('g')
           .data(data, d4.functor(scope.accessors.key).bind(this));
-        group.enter().append('g')
+
+        labelGroups.enter().append('g')
           .attr('class', function(d, i) {
             return 'series' + i + ' ' + this.x.$key;
           }.bind(this));
-        group.exit().remove();
 
-        var text = group.selectAll('text')
+        labelGroups.exit().remove();
+
+        var text = labelGroups.selectAll('text')
           .data(function(d) {
             return d.values;
           }.bind(this));

--- a/src/features/stacked-labels.js
+++ b/src/features/stacked-labels.js
@@ -115,9 +115,6 @@
           .attr('y', d4.functor(scope.accessors.y).bind(this))
           .attr('x', d4.functor(scope.accessors.x).bind(this));
 
-        labelGroups.exit().remove();
-        text.exit().remove();
-
         if (d4.functor(scope.accessors.stagger).bind(this)()) {
 
           // FIXME: This should be moved into a helper injected using DI.
@@ -139,6 +136,8 @@
             });
           });
         });
+        labelGroups.exit().remove();
+        text.exit().remove();
         return text;
       }
     };

--- a/src/features/stacked-shapes-series.js
+++ b/src/features/stacked-shapes-series.js
@@ -54,19 +54,19 @@
       },
 
       render: function(scope, data, selection) {
-        selection.append('g').attr('class', name);
+        var group = d4.appendOnce(selection, 'g.' + name);
 
         // create data join with the series data
-        var group = this.container.select('.' + name).selectAll('g')
+        var shapeGroups = group.selectAll('g')
           .data(data, d4.functor(scope.accessors.key).bind(this));
 
-        group.enter().append('g')
+        shapeGroups.enter().append('g')
           .attr('class', function(d, i) {
             return 'series' + i + ' ' + this.y.$key;
           }.bind(this));
-        group.exit().remove();
+        shapeGroups.exit().remove();
 
-        var shape = group.selectAll(shapeType)
+        var shape = shapeGroups.selectAll(shapeType)
           .data(function(d) {
             return d.values;
           });

--- a/src/features/stacked-shapes-series.js
+++ b/src/features/stacked-shapes-series.js
@@ -76,6 +76,7 @@
         renderShapeAttributes.bind(this)(scope, shape);
 
         shape.exit().remove();
+        shapeGroups.exit().remove();
         return shape;
       }
     };

--- a/src/features/waterfall-connectors.js
+++ b/src/features/waterfall-connectors.js
@@ -59,8 +59,8 @@
       },
 
       render: function(scope, data, selection) {
-        selection.append('g').attr('class', name);
-        var lines = this.container.select('.' + name).selectAll('.' + name).data(data);
+        var group = d4.appendOnce(selection, 'g.' + name);
+        var lines = group.selectAll('line').data(data);
         lines.enter().append('line');
         lines.exit().remove();
         lines

--- a/src/features/x-axis.js
+++ b/src/features/x-axis.js
@@ -103,9 +103,7 @@
         var title = textRect(d4.functor(scope.accessors.title).bind(this)(), 'title');
         var subtitle = textRect(d4.functor(scope.accessors.subtitle).bind(this)(), 'subtitle');
         var aligned = d4.functor(scope.accessors.align).bind(this)();
-        var group = this.container.select('g.margins')
-          .append('g')
-          .attr('class', 'x axis ' + name)
+        var group = d4.appendOnce(this.container.select('g.margins'), 'g.x.axis.' + name)
           .attr('data-scale', this.x.$scale)
           .call(axis);
         alignAxis.bind(this)(aligned, group);

--- a/src/features/y-axis.js
+++ b/src/features/y-axis.js
@@ -103,9 +103,7 @@
         var subtitle = textRect(d4.functor(scope.accessors.subtitle).bind(this)(), 'subtitle');
         var aligned = d4.functor(scope.accessors.align).bind(this)();
 
-        var group = this.container.select('g.margins')
-          .append('g')
-          .attr('class', 'y axis ' + name)
+        var group = d4.appendOnce(this.container.select('g.margins'), 'g.y.axis.' + name)
           .attr('data-scale', this.y.$scale)
           .call(axis);
 


### PR DESCRIPTION
This PR uses the handy `d4.appendOnce` convention for new series and axes. It then does a data bind and reselects the elements to apply attributes. This prevents features from being drawn twice. You can see, for example, in the [dynamic data](http://visible.io/charts/column/dynamic-update.html) example, that the axes are re-appended every render. This PR fixes that, and should also make the transitions API easier to implement for column, shape, and line series.

Note I didn't rebuild the project, just trying to keep the diff clean.