### PR TITLE
Use nested axes for groups

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -276,8 +276,8 @@
       link: function(chart, data) {
         d4.builders[chart.x.$scale + 'ScaleForNestedData'](chart, data, 'x');
         d4.builders[chart.y.$scale + 'ScaleForNestedData'](chart, data, 'y');
-        if (chart.x1) {
-          d4.builders[chart.x1.$scale + 'ScaleForNestedData'](chart, data, 'x1');
+        if (chart.groups) {
+          d4.builders[chart.groups.$scale + 'ScaleForNestedData'](chart, data, 'groups');
         }
       }
     });

--- a/src/base.js
+++ b/src/base.js
@@ -276,6 +276,9 @@
       link: function(chart, data) {
         d4.builders[chart.x.$scale + 'ScaleForNestedData'](chart, data, 'x');
         d4.builders[chart.y.$scale + 'ScaleForNestedData'](chart, data, 'y');
+        if (chart.x1) {
+          d4.builders[chart.x1.$scale + 'ScaleForNestedData'](chart, data, 'x1');
+        }
       }
     });
     var chartAccessors = d4.merge({}, config.accessors);

--- a/src/builders/scales.js
+++ b/src/builders/scales.js
@@ -7,7 +7,7 @@
         return i[key];
       }.bind(this));
     }.bind(this));
-    return d3.merge(values);
+    return d3.set(d3.merge(values)).values();
   };
 
   var rangeFor = function(chart, dimension) {
@@ -96,4 +96,5 @@
     }
     return axis;
   });
+
 }).call(this);

--- a/src/builders/scales.js
+++ b/src/builders/scales.js
@@ -18,6 +18,14 @@
         return [0, chart.width];
       case 'y':
         return [chart.height, 0];
+      case 'groups':
+        var groupDimension = chart.axes.groups.$dimension;
+        if (groupDimension === 'x') {
+          return [0, chart.axes.x.rangeBand()];
+        } else {
+          return [chart.axes.y.rangeBand(), 0];
+        }
+        break;
       default:
         return [];
     }
@@ -85,7 +93,19 @@
    */
   d4.builder('ordinalScaleForNestedData', function(chart, data, dimension) {
     var parsedData = extractValues(data, chart[dimension].$key);
-    var bands = chart[dimension + 'RoundBands'] = chart[dimension + 'RoundBands'] || 0.3;
+
+    // Apply the padding to a `rangeRoundBands` d3 scale. Check for a custom
+    // or existing padding set by the scale, otherwise provide a default.
+    var bands;
+    if (chart[dimension + 'RoundBands']) {
+      bands = chart[dimension + 'RoundBands'];
+    } else if (chart[dimension].$roundBands) {
+      bands = chart[dimension].$roundBands;
+    } else {
+      bands = 0.3;
+    }
+    chart[dimension + 'RoundBands'] = bands;
+
     var axis = chart[dimension];
     if (!axis.domain.$dirty) {
       axis.domain(parsedData);

--- a/src/charts/grouped-column.js
+++ b/src/charts/grouped-column.js
@@ -60,8 +60,7 @@
           x: function(d, i) {
             var width = this.x.rangeBand() / this.groupsOf;
             var xPos = this.x(d[this.x.$key]) + width * i;
-            var gutter = width * 0.1;
-            return xPos + width / 2 - gutter;
+            return xPos + width / 2;
           }
         }
       };
@@ -69,8 +68,14 @@
 
     return d4.baseChart({
       config: {
+        axes: {
+          x1: {
+            scale: 'ordinal'
+          }
+        },
         accessors: {
-          groupsOf: 1
+          groupsOf: 1,
+          columnPadding: 0.1
         }
       }
     })

--- a/src/charts/grouped-column.js
+++ b/src/charts/grouped-column.js
@@ -57,10 +57,11 @@
     var columnLabelOverrides = function() {
       return {
         accessors: {
-          x: function(d, i) {
-            var width = this.x.rangeBand() / this.groupsOf;
-            var xPos = this.x(d[this.x.$key]) + width * i;
-            return xPos + width / 2;
+          x: function(d) {
+            var groupX = this.x(d[this.x.$key]);
+            var rectX = this.groups(d[this.groups.$key]);
+            var rectWidthOffset = this.groups.rangeBand() / 2;
+            return groupX + rectX + rectWidthOffset;
           }
         }
       };
@@ -69,13 +70,14 @@
     return d4.baseChart({
       config: {
         axes: {
-          x1: {
-            scale: 'ordinal'
+          groups: {
+            scale: 'ordinal',
+            dimension: 'x',
+            roundBands: 0.1
           }
         },
         accessors: {
-          groupsOf: 1,
-          columnPadding: 0.1
+          groupsOf: 1
         }
       }
     })

--- a/src/charts/grouped-row.js
+++ b/src/charts/grouped-row.js
@@ -70,7 +70,8 @@
     return d4.baseChart({
       config: {
         accessors: {
-          groupsOf: 1
+          groupsOf: 1,
+          rowPadding: 0.1
         },
         margin: {
           top: 20,
@@ -83,6 +84,9 @@
             scale: 'linear'
           },
           y: {
+            scale: 'ordinal'
+          },
+          y1: {
             scale: 'ordinal'
           }
         }

--- a/src/charts/grouped-row.js
+++ b/src/charts/grouped-row.js
@@ -57,11 +57,11 @@
     var rowLabelOverrides = function() {
       return {
         accessors: {
-          y: function(d, i) {
-            var height = this.y.rangeBand() / this.groupsOf;
-            var yPos = this.y(d[this.y.$key]) + height * i;
-            var gutter = height * 0.1;
-            return yPos + height / 4 + gutter;
+          y: function(d) {
+            var groupY = this.y(d[this.y.$key]);
+            var rectY = this.groups(d[this.groups.$key]);
+            var rectHeightOffset = this.groups.rangeBand() / 3;
+            return groupY + rectY + rectHeightOffset;
           }
         }
       };
@@ -70,8 +70,7 @@
     return d4.baseChart({
       config: {
         accessors: {
-          groupsOf: 1,
-          rowPadding: 0.1
+          groupsOf: 1
         },
         margin: {
           top: 20,
@@ -86,8 +85,10 @@
           y: {
             scale: 'ordinal'
           },
-          y1: {
-            scale: 'ordinal'
+          groups: {
+            scale: 'ordinal',
+            dimension: 'y',
+            roundBands: 0.1
           }
         }
       }

--- a/src/features/grouped-column-series.js
+++ b/src/features/grouped-column-series.js
@@ -17,7 +17,7 @@
     var useDiscreteGroupPosition = function(d) {
       var dimension = this.groups.$dimension;
       var axis = this[dimension];
-      var pos = axis(d.key);
+      var pos = axis(d.values[0][axis.$key]);
       var translate;
       if (dimension === 'x') {
         translate = [pos, 0];


### PR DESCRIPTION
Hello. So the more flexible and canonical way to do grouped columns/rows in d3 is to have what I'm calling "nested axes", meaning an outer axis to place the groups and an inner one to place the series within each group. See [this example](http://bl.ocks.org/EE2dev/af14387f43b5f332e360).

I've refactored `grouped-column-series` to use this kind of implementation. This fixes https://github.com/heavysixer/d4/issues/25 and https://github.com/heavysixer/d4/issues/10, which as far as I can tell are the same issue. It also removes some hard-coding in the size and placement of the groups and such, because values are set according to the `rangeBand` of the outer axis. You can check against my [grouped-axes branch](https://github.com/nsonnad/d4-www/tree/grouped-axes) on `d4-www` to see it in action. All of the grouped column/row examples work as far as I can tell.

My naming treats `x` or `y` as the outer axis, and `groups` as the inner.

I'm curious to see if you have any feedback on the stuff in `scales.js` and `base.js`, as some of the checks in there seem a bit dirty. Also, customizing the inner axis is not possible through the chart definition because it needs the `rangeBand()` of the outer axis to determine the range. So I've included `roundBands` as a customizable property of the `groups` scale.

I should note as well that this is a breaking change as the `groups` axis key is required. It may be possible to fall back to an index, but I'm not so sure how to do that at the moment. Thanks and sorry for the long winded explanation!