### PR TITLE
fix arc series transition by only setting initial value on enter

### DIFF
--- a/src/features/arc-series.js
+++ b/src/features/arc-series.js
@@ -80,7 +80,9 @@
             return d.values;
           }, d4.functor(scope.accessors.key).bind(this));
 
-        arcs.enter().append('path');
+        arcs.enter().append('path')
+          .each(function(d) { this._current = d; });
+
         // update
         arcs.transition()
           .duration(d4.functor(scope.accessors.duration).bind(this)())
@@ -89,10 +91,7 @@
         // create new elements as needed
         arcs.attr('class', d4.functor(scope.accessors.classes).bind(this))
           .attr('data-key', d4.functor(scope.accessors.key).bind(this))
-          .attr('d', arc)
-          .each(function(d) {
-            this._current = d;
-          });
+          .attr('d', arc);
 
         //remove old elements as needed
         arcs.exit().remove();


### PR DESCRIPTION
This is a fix for https://github.com/heavysixer/d4/issues/30. (Sorry about that.) This is a specific problem for arc series, essentially it was setting `this._current` whenever it got data (not just the first time) so it was interpolating to the newest value.

The changes I made allow the transitions API used in arc series to be used in any chart type. For example try slapping a `transition()` on the `rectSeries` selection and view the waterfall. Perhaps we should think about exposing transitions for these types as well?