### PR TITLE
Set axis min for column height using scaleId

### DIFF
--- a/src/features/column-labels.js
+++ b/src/features/column-labels.js
@@ -53,6 +53,8 @@
         }
       },
       render: function(scope, data, selection) {
+        var xScaleId = d4.functor(scope.accessors.xScaleId)();
+        var yScaleId = d4.functor(scope.accessors.yScaleId)();
         var group = d4.appendOnce(selection, 'g.' + name);
         var label = group.selectAll('text')
           .data(data, d4.functor(scope.accessors.key).bind(this));
@@ -61,8 +63,8 @@
         label.attr('class', 'column-label ' + name)
           .text(d4.functor(scope.accessors.text).bind(this))
           .attr('text-anchor', anchorText.bind(this))
-          .attr('x', d4.functor(scope.accessors.x).bind(this, scope.accessors.xScaleId()))
-          .attr('y', d4.functor(scope.accessors.y).bind(this, scope.accessors.yScaleId()));
+          .attr('x', d4.functor(scope.accessors.x).bind(this, xScaleId))
+          .attr('y', d4.functor(scope.accessors.y).bind(this, yScaleId));
         return label;
       }
     };

--- a/src/features/column-labels.js
+++ b/src/features/column-labels.js
@@ -20,26 +20,36 @@
       accessors: {
         key: d4.functor(d4.defaultKey),
 
-        x: function(d) {
-          if (d4.isOrdinalScale(this.x)) {
-            return this.x(d[this.x.$key]) + (this.x.rangeBand() / 2);
+        x: function(xScaleId, d) {
+          var axis = this[xScaleId];
+          if (d4.isOrdinalScale(axis)) {
+            return axis(d[axis.$key]) + (axis.rangeBand() / 2);
           } else {
-            var width = Math.abs(this.x(d[this.x.$key]) - this.x(0));
-            return this.x(d[this.x.$key]) - width / 2;
+            var width = Math.abs(axis(d[axis.$key]) - axis(0));
+            return axis(d[axis.$key]) - width / 2;
           }
         },
 
-        y: function(d) {
-          if (d4.isOrdinalScale(this.y)) {
-            return this.y(d[this.y.$key]) + (this.y.rangeBand() / 2) + padding;
+        y: function(yScaleId, d) {
+          var axis = this[yScaleId];
+          if (d4.isOrdinalScale(axis)) {
+            return axis(d[axis.$key]) + (axis.rangeBand() / 2) + padding;
           } else {
-            var height = Math.abs(this.y(d[this.y.$key]) - this.y(0));
-            return (d[this.y.$key] < 0 ? this.y(d[this.y.$key]) - height : this.y(d[this.y.$key])) - padding;
+            var height = Math.abs(axis(d[axis.$key]) - axis(0));
+            return (d[axis.$key] < 0 ? axis(d[axis.$key]) - height : axis(d[axis.$key])) - padding;
           }
         },
 
         text: function(d) {
           return d[this.valueKey];
+        },
+
+        xScaleId: function() {
+          return 'x';
+        },
+
+        yScaleId: function() {
+          return 'y';
         }
       },
       render: function(scope, data, selection) {
@@ -51,8 +61,8 @@
         label.attr('class', 'column-label ' + name)
           .text(d4.functor(scope.accessors.text).bind(this))
           .attr('text-anchor', anchorText.bind(this))
-          .attr('x', d4.functor(scope.accessors.x).bind(this))
-          .attr('y', d4.functor(scope.accessors.y).bind(this));
+          .attr('x', d4.functor(scope.accessors.x).bind(this, scope.accessors.xScaleId()))
+          .attr('y', d4.functor(scope.accessors.y).bind(this, scope.accessors.yScaleId()));
         return label;
       }
     };

--- a/src/features/grouped-column-series.js
+++ b/src/features/grouped-column-series.js
@@ -33,7 +33,9 @@
 
     var useContinuousSize = function(dimension, d) {
       var axis = this[dimension];
-      return Math.abs(axis(d[axis.$key]) - axis(0));
+      var domainMin = axis.domain()[0];
+      var axisMin = (domainMin < 0) ? 0 : domainMin;
+      return Math.abs(axis(d[axis.$key]) - axis(axisMin));
     };
 
     var useContinuousPosition = function(dimension, d) {
@@ -53,11 +55,11 @@
           return 'bar fill item' + i + ' ' + sign(d[this.valueKey]) + ' ' + d[this.valueKey];
         },
 
-        height: function(d) {
+        height: function(yScaleId, d) {
           if (d4.isOrdinalScale(this.y)) {
-            return useDiscreteSize.bind(this)('y');
+            return useDiscreteSize.bind(this)(yScaleId);
           } else {
-            return useContinuousSize.bind(this)('y', d);
+            return useContinuousSize.bind(this)(yScaleId, d);
           }
         },
 
@@ -67,11 +69,11 @@
 
         ry: 0,
 
-        width: function(d) {
+        width: function(xScaleId, d) {
           if (d4.isOrdinalScale(this.x)) {
             return useDiscreteSize.bind(this)();
           } else {
-            return useContinuousSize.bind(this)('x', d);
+            return useContinuousSize.bind(this)(xScaleId, d);
           }
         },
 
@@ -94,12 +96,22 @@
             return useContinuousPosition.bind(this)('y', d, i);
           }
         },
+
+        xScaleId: function() {
+          return 'x';
+        },
+
+        yScaleId: function() {
+          return 'y';
+        }
       },
       render: function(scope, data, selection) {
         if (data.length > 0) {
           this.groupsOf = this.groupsOf || data[0].values.length;
         }
 
+        var xScaleId = d4.functor(scope.accessors.xScaleId)();
+        var yScaleId = d4.functor(scope.accessors.yScaleId)();
         var group = d4.appendOnce(selection, 'g.' + name);
 
         var columnGroups = group.selectAll('g')
@@ -124,8 +136,8 @@
           .attr('y', d4.functor(scope.accessors.y).bind(this))
           .attr('ry', d4.functor(scope.accessors.ry).bind(this))
           .attr('rx', d4.functor(scope.accessors.rx).bind(this))
-          .attr('width', d4.functor(scope.accessors.width).bind(this))
-          .attr('height', d4.functor(scope.accessors.height).bind(this));
+          .attr('width', d4.functor(scope.accessors.width).bind(this, xScaleId))
+          .attr('height', d4.functor(scope.accessors.height).bind(this, yScaleId));
 
         rect.exit().remove();
         columnGroups.exit().remove();


### PR DESCRIPTION
This is a fix for #36. The issue was that the height was using `0` as an axis min in `useContiunuousSize`. This PR adds `xScaleId` and `yScaleId` accessors for `groupedColumnSeries` and `rectSeries`, and this id is used to get the correct axis min. I have updated the multi-dimension in example in `d4-www` to draw this way, see [this branch](https://github.com/nsonnad/d4-www/tree/dual-axis-column).