### PR TITLE
docs: Fix simple typo, continious -> continuous

### DIFF
--- a/d4.js
+++ b/d4.js
@@ -1994,7 +1994,7 @@ var d4;
 
   /*
    * The stacked column chart has two axes (`x` and `y`). By default the stacked
-   * column expects continious scale for the `y` axis and a discrete scale for
+   * column expects continuous scale for the `y` axis and a discrete scale for
    * the `x` axis. The stacked column has the following default features:
    *
    *##### Features
@@ -2139,7 +2139,7 @@ var d4;
   'use strict';
   /*
    * The stacked row chart has two axes (`x` and `y`). By default the stacked
-   * row expects continious scale for the `x` axis and a discrete scale for
+   * row expects continuous scale for the `x` axis and a discrete scale for
    * the `y` axis. The stacked row has the following default features:
    *
    *##### Features
@@ -2448,7 +2448,7 @@ var d4;
    * if you have used think-cell.
    *
    * The waterfall chart has two axes (`x` and `y`). By default the stacked
-   * column expects continious scale for the `y` axis and a discrete scale for
+   * column expects continuous scale for the `y` axis and a discrete scale for
    * the `x` axis. This will render the waterfall chart vertically. However,
    * if you swap the scale types then the waterfall will render horizontally.
    *

--- a/d4.min.js
+++ b/d4.min.js
@@ -721,7 +721,7 @@ var c=5,d=Math.max(c+1,(a.height-a.margin.top-a.margin.bottom)/10);a.z.range([c,
    */
 d4.chart("scatterPlot",function(b){var c=b||{};return d4.baseChart(d4.extend({builder:a,config:{axes:{x:{scale:"linear"},z:{scale:"linear"}}}},c)).mixin([{name:"circles",feature:d4.features.circleSeries,overrides:e},{name:"circleLabels",feature:d4.features.stackedLabels,overrides:d},{name:"xAxis",feature:d4.features.xAxis},{name:"yAxis",feature:d4.features.yAxis}])})}.call(this),function(){"use strict";/*
    * The stacked column chart has two axes (`x` and `y`). By default the stacked
-   * column expects continious scale for the `y` axis and a discrete scale for
+   * column expects continuous scale for the `y` axis and a discrete scale for
    * the `x` axis. The stacked column has the following default features:
    *
    *##### Features
@@ -780,7 +780,7 @@ d4.chart("scatterPlot",function(b){var c=b||{};return d4.baseChart(d4.extend({bu
    */
 d4.chart("stackedColumn",function(a){var b=a||{},c=function(){var a=function(a){var b=[];return a.map(function(a){a.values.map(function(a){b.push(a)})}),b},b=function(a){return d3.nest().key(function(a){return a[this.x.$key]}.bind(this)).rollup(function(a){var b=d3.sum(a,function(a){return a[this.valueKey]}.bind(this)),c=d3.sum(a,function(a){return Math.max(0,a[this.valueKey])}.bind(this));return{text:b,size:c}}.bind(this)).entries(a)},c=function(c){return b.bind(this)(a(c)).map(function(a){var b={};return b[this.x.$key]=a.key,b.size=a.values.size,b[this.valueKey]=a.values.text,b}.bind(this))};return{accessors:{beforeRender:function(a){return c.bind(this)(a)},y:function(a,b){var c=this[a],d=5;return c(b.size)-d}}}};return d4.baseChart(b).mixin([{name:"bars",feature:d4.features.rectSeries},{name:"barLabels",feature:d4.features.stackedLabels},{name:"connectors",feature:d4.features.stackedColumnConnectors},{name:"columnTotals",feature:d4.features.columnLabels,overrides:c},{name:"xAxis",feature:d4.features.xAxis},{name:"yAxis",feature:d4.features.yAxis}])})}.call(this),function(){"use strict";/*
    * The stacked row chart has two axes (`x` and `y`). By default the stacked
-   * row expects continious scale for the `x` axis and a discrete scale for
+   * row expects continuous scale for the `x` axis and a discrete scale for
    * the `y` axis. The stacked row has the following default features:
    *
    *##### Features
@@ -849,7 +849,7 @@ return a.y+a.y0})})));e[0]=d4.isDefined(b[c].$min)?b[c].$min:Math.min(0,e[0]),d4
    * if you have used think-cell.
    *
    * The waterfall chart has two axes (`x` and `y`). By default the stacked
-   * column expects continious scale for the `y` axis and a discrete scale for
+   * column expects continuous scale for the `y` axis and a discrete scale for
    * the `x` axis. This will render the waterfall chart vertically. However,
    * if you swap the scale types then the waterfall will render horizontally.
    *

--- a/docs/d4-doc.md
+++ b/docs/d4-doc.md
@@ -1346,7 +1346,7 @@ has these default features:
 [Ⓣ][52]
 
 The stacked column chart has two axes (`x` and `y`). By default the stacked  
-column expects continious scale for the `y` axis and a discrete scale for  
+column expects continuous scale for the `y` axis and a discrete scale for  
 the `x` axis. The stacked column has the following default features:
 
 ##### Features
@@ -1412,7 +1412,7 @@ the `x` axis. The stacked column has the following default features:
 [Ⓣ][54]
 
 The stacked row chart has two axes (`x` and `y`). By default the stacked  
-row expects continious scale for the `x` axis and a discrete scale for  
+row expects continuous scale for the `x` axis and a discrete scale for  
 the `y` axis. The stacked row has the following default features:
 
 ##### Features
@@ -1485,7 +1485,7 @@ column by passing in an "e" as the value key, which may be a familiar convention
 if you have used think-cell.
 
 The waterfall chart has two axes (`x` and `y`). By default the stacked  
-column expects continious scale for the `y` axis and a discrete scale for  
+column expects continuous scale for the `y` axis and a discrete scale for  
 the `x` axis. This will render the waterfall chart vertically. However,  
 if you swap the scale types then the waterfall will render horizontally.
 

--- a/src/charts/stacked-column.js
+++ b/src/charts/stacked-column.js
@@ -3,7 +3,7 @@
 
   /*
    * The stacked column chart has two axes (`x` and `y`). By default the stacked
-   * column expects continious scale for the `y` axis and a discrete scale for
+   * column expects continuous scale for the `y` axis and a discrete scale for
    * the `x` axis. The stacked column has the following default features:
    *
    *##### Features

--- a/src/charts/stacked-row.js
+++ b/src/charts/stacked-row.js
@@ -2,7 +2,7 @@
   'use strict';
   /*
    * The stacked row chart has two axes (`x` and `y`). By default the stacked
-   * row expects continious scale for the `x` axis and a discrete scale for
+   * row expects continuous scale for the `x` axis and a discrete scale for
    * the `y` axis. The stacked row has the following default features:
    *
    *##### Features

--- a/src/charts/waterfall.js
+++ b/src/charts/waterfall.js
@@ -148,7 +148,7 @@
    * if you have used think-cell.
    *
    * The waterfall chart has two axes (`x` and `y`). By default the stacked
-   * column expects continious scale for the `y` axis and a discrete scale for
+   * column expects continuous scale for the `y` axis and a discrete scale for
    * the `x` axis. This will render the waterfall chart vertically. However,
    * if you swap the scale types then the waterfall will render horizontally.
    *

--- a/test/lib/d4.js
+++ b/test/lib/d4.js
@@ -1994,7 +1994,7 @@ var d4;
 
   /*
    * The stacked column chart has two axes (`x` and `y`). By default the stacked
-   * column expects continious scale for the `y` axis and a discrete scale for
+   * column expects continuous scale for the `y` axis and a discrete scale for
    * the `x` axis. The stacked column has the following default features:
    *
    *##### Features
@@ -2139,7 +2139,7 @@ var d4;
   'use strict';
   /*
    * The stacked row chart has two axes (`x` and `y`). By default the stacked
-   * row expects continious scale for the `x` axis and a discrete scale for
+   * row expects continuous scale for the `x` axis and a discrete scale for
    * the `y` axis. The stacked row has the following default features:
    *
    *##### Features
@@ -2448,7 +2448,7 @@ var d4;
    * if you have used think-cell.
    *
    * The waterfall chart has two axes (`x` and `y`). By default the stacked
-   * column expects continious scale for the `y` axis and a discrete scale for
+   * column expects continuous scale for the `y` axis and a discrete scale for
    * the `x` axis. This will render the waterfall chart vertically. However,
    * if you swap the scale types then the waterfall will render horizontally.
    *

--- a/test/tests/d4-bundle.js
+++ b/test/tests/d4-bundle.js
@@ -1995,7 +1995,7 @@ var d4;
 
   /*
    * The stacked column chart has two axes (`x` and `y`). By default the stacked
-   * column expects continious scale for the `y` axis and a discrete scale for
+   * column expects continuous scale for the `y` axis and a discrete scale for
    * the `x` axis. The stacked column has the following default features:
    *
    *##### Features
@@ -2140,7 +2140,7 @@ var d4;
   'use strict';
   /*
    * The stacked row chart has two axes (`x` and `y`). By default the stacked
-   * row expects continious scale for the `x` axis and a discrete scale for
+   * row expects continuous scale for the `x` axis and a discrete scale for
    * the `y` axis. The stacked row has the following default features:
    *
    *##### Features
@@ -2449,7 +2449,7 @@ var d4;
    * if you have used think-cell.
    *
    * The waterfall chart has two axes (`x` and `y`). By default the stacked
-   * column expects continious scale for the `y` axis and a discrete scale for
+   * column expects continuous scale for the `y` axis and a discrete scale for
    * the `x` axis. This will render the waterfall chart vertically. However,
    * if you swap the scale types then the waterfall will render horizontally.
    *


### PR DESCRIPTION
There is a small typo in d4.js, d4.min.js, docs/d4-doc.md, src/charts/stacked-column.js, src/charts/stacked-row.js, src/charts/waterfall.js, test/lib/d4.js, test/tests/d4-bundle.js.

Should read `continuous` rather than `continious`.

